### PR TITLE
deleted old fauna key from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "npm-run-all --parallel build:**",
     "develop": "gatsby develop",
     "start:app": "npm run develop",
-    "start:server": "FAUNA_KEY=fnAC-8TFy5ACARqo1n6UCnON6XTCYivQ3MShAdXw netlify-lambda serve functions-src -c ./webpack.config.js",
+    "start:server": "netlify-lambda serve functions-src -c ./webpack.config.js",
     "start": "npm-run-all --parallel start:app start:server",
     "format": "prettier --write \"src/**/*.js\"",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
For now we'll have to set it locally on the command line or in .bashrc

One possible future fix might be to put it in a development-only toml file

Sidenote: I tried to resolve npm package vulnerabilities but was unable to. Tunnel-agent <= 0.6.0 has something like a memory leakage. 0.6.0 is the latest version :(